### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/gmp/listers.py
+++ b/gmp/listers.py
@@ -190,7 +190,7 @@ protocol: used for cloning the repository (choices: ssh/https/git)"""
         
         RepoLister.__init__(self, **kwargs)
         self.username = username
-        if self.username == None:
+        if self.username is None:
             cmd = "git config --get github.user"
             process = subprocess.Popen(cmd, shell = True,
                                        stdout = subprocess.PIPE,

--- a/gmp/policy.py
+++ b/gmp/policy.py
@@ -19,7 +19,7 @@ your working directory you can define a policy for this repository,
 that it is only visible on your local machine."""
         result = False
         for (regexp, policy) in self.policies:
-            if re.match(".*" + regexp, hostname) != None:
+            if re.match(".*" + regexp, hostname) is not None:
                 if policy == "allow":
                     result = True
                 else:

--- a/gmp/repository.py
+++ b/gmp/repository.py
@@ -31,7 +31,7 @@ default_policy: defines if the repo can be cloned on all machines ("allow") or n
         self.clone_url = clone_url
         # If no local_url is specified, we use the last part of the clone url
         # without the .git
-        if local_url == None:
+        if local_url is None:
             m = re.match(".*/([^/]+?)(\\." + scm.binary + ")?$", clone_url)
             if m:
                 # Remove .git / .hg or whatever

--- a/gmp/scm.py
+++ b/gmp/scm.py
@@ -213,7 +213,7 @@ class GitSvn(Git):
         # Append -r HEAD to command, so only the top commit is cloned
         if self.headonly:
             opts = ['-r', 'HEAD']
-        elif self.limit != None:
+        elif self.limit is not None:
             opts = ["--limit", str(self.limit)]
         else:
             opts = []


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:metagit?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:metagit?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
