### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/gmp/listers.py
+++ b/gmp/listers.py
@@ -78,9 +78,9 @@ class RepoLister (PolicyMixin):
         repos = self.create_repos()
         if self.cache and len (repos) > 0:
             cache = open(self.cache, "w+")
-            cache.write("[%s" % str(repos[0]))
+            cache.write("[{0!s}".format(str(repos[0])))
             for r in repos[1:]:
-                cache.write(",\n %s" % str(r))
+                cache.write(",\n {0!s}".format(str(r)))
             cache.write("]")
             cache.close()
         return repos.__iter__()
@@ -113,9 +113,9 @@ directory: remote directory where the git repos are searched"""
         self.clone_urls = []
         for repo in process.stdout.readlines():
             # Finding none bare repositories
-            m = re.match("^(.*)/\.%s$" % self.scm.binary, repo)
+            m = re.match("^(.*)/\.{0!s}$".format(self.scm.binary), repo)
             m = m or re.match("(.*)/refs$", repo)
-            if m and not re.match(".*(svn|logs)/refs", repo) and not re.match(".*\.%s/" % self.scm.binary, repo):
+            if m and not re.match(".*(svn|logs)/refs", repo) and not re.match(".*\.{0!s}/".format(self.scm.binary), repo):
                 remote = m.group(1)
                 local = remote[len(self.directory)+1:]
                 self.clone_urls.append((self.host + ":" + remote, local))
@@ -127,10 +127,10 @@ directory: remote directory where the git repos are searched"""
     def upload(self, local, remote):
         """Uploads a local repository with scp to a remote location"""
 
-        push_url = "%s:%s" %(self.host,
+        push_url = "{0!s}:{1!s}".format(self.host,
                              os.path.join(self.directory, remote))
         
-        cmd = "scp -r %s %s"% (esc(local),
+        cmd = "scp -r {0!s} {1!s}".format(esc(local),
                                esc(push_url))
         print cmd
         a = subprocess.Popen(cmd, shell = True)
@@ -206,7 +206,7 @@ protocol: used for cloning the repository (choices: ssh/https/git)"""
         self.protocol = protocol
 
     def get_list(self):
-        js = urllib2.urlopen("https://api.github.com/users/%s/repos"%self.username).read()
+        js = urllib2.urlopen("https://api.github.com/users/{0!s}/repos".format(self.username)).read()
         repos = json.loads(js)
         self.clone_urls = []
         for repo in repos:
@@ -219,11 +219,11 @@ protocol: used for cloning the repository (choices: ssh/https/git)"""
     def github_url(self, name):
         url = ""
         if self.protocol == "ssh":
-            url = "git@github.com:%s/%s.git" % (self.username, name)
+            url = "git@github.com:{0!s}/{1!s}.git".format(self.username, name)
         elif self.protocol == "https":
-            url = "https://%s@github.com/%s/%s.git" %(self.username, self.username, name)
+            url = "https://{0!s}@github.com/{1!s}/{2!s}.git".format(self.username, self.username, name)
         else:
-            url = "git://github.com/%s/%s.git" %(self.username, name)
+            url = "git://github.com/{0!s}/{1!s}.git".format(self.username, name)
         return url
         
     def can_upload(self):
@@ -244,7 +244,7 @@ Please set the github.token variable via git config"""
             print "ERROR: Please define github.token via git config"
             sys.exit(-1)
 
-        print "Creating new remote repository '%s'" % remote
+        print "Creating new remote repository '{0!s}'".format(remote)
         data = urllib.urlencode({'login': self.username, 'token': token, 'name': remote})
         try:
             xml = urllib2.urlopen("http://github.com/api/v2/xml/repos/create", data = data)
@@ -253,7 +253,7 @@ Please set the github.token variable via git config"""
             sys.exit(-1)
         xml.close()
 
-        cmd = "cd %s; git push %s master" % (esc(local),
+        cmd = "cd {0!s}; git push {1!s} master".format(esc(local),
                                              esc(self.github_url(remote)))
         print cmd
         a = subprocess.Popen(cmd, shell = True)
@@ -298,17 +298,17 @@ protocol: used for cloning the repository (choices: ssh/http/git)"""
         self.gitorious = gitorious
 
     def get_list(self):
-        print "http://%s/~%s"%(self.gitorious, self.username)
-        site = urllib2.urlopen("https://%s/~%s"%(self.gitorious, self.username))
+        print "http://{0!s}/~{1!s}".format(self.gitorious, self.username)
+        site = urllib2.urlopen("https://{0!s}/~{1!s}".format(self.gitorious, self.username))
         lines_to_read = 0
 
         self.clone_urls = []
-        prefixes = {"ssh": "git@%s:"%self.gitorious,
-                    "http": "git.%s/"%self.gitorious,
-                    "git": "git://%s/"%self.gitorious}
+        prefixes = {"ssh": "git@{0!s}:".format(self.gitorious),
+                    "http": "git.{0!s}/".format(self.gitorious),
+                    "git": "git://{0!s}/".format(self.gitorious)}
 
         if not self.protocol in prefixes:
-            print "Protocol %s not supported by gitorious list plugin" % self.protocol
+            print "Protocol {0!s} not supported by gitorious list plugin".format(self.protocol)
             sys.exit(-1)
 
         # FIXME: Find a good API for gitorious cause this frickel
@@ -335,7 +335,7 @@ protocol: used for cloning the repository (choices: ssh/https/git)"""
             kwargs['name'] = "gitlab"
 
         RepoLister.__init__(self, **kwargs)
-        cmd = "git config --get gitlab.%s.token" % host
+        cmd = "git config --get gitlab.{0!s}.token".format(host)
         process = subprocess.Popen(cmd, shell = True,
                                    stdout = subprocess.PIPE,
                                    stderr = subprocess.PIPE)
@@ -351,7 +351,7 @@ protocol: used for cloning the repository (choices: ssh/https/git)"""
 
     def get_list(self):
         headers = {"PRIVATE-TOKEN": self.gitlab_token}
-        url = "https://%s/api/v3/projects/owned" % self.host
+        url = "https://{0!s}/api/v3/projects/owned".format(self.host)
         request = urllib2.Request(url, headers=headers)
         js = urllib2.urlopen(request).read()
         repos = json.loads(js)

--- a/gmp/main.py
+++ b/gmp/main.py
@@ -70,9 +70,9 @@ line interface"""
         
         text += """
   A selector is a regexp which is checked against the output of metagit
-  list. (Exception: states (%s), current repository (.).
+  list. (Exception: states ({0!s}), current repository (.).
 
-""" %(", ".join(SCM.states))
+""".format((", ".join(SCM.states)))
 
         # Find longest command
         length = max( [ len(x) for x in self.commands.keys() ] )
@@ -165,7 +165,7 @@ line interface"""
 
     def shortcut(self, command, help = None):
         if not help:
-            help = "[selector] - executes <scm> %s on repositories" %(command,)
+            help = "[selector] - executes <scm> {0!s} on repositories".format(command)
         func = lambda x: self.cmd_foreach([self._shortcut(x)[0], command] + self._shortcut(x)[1:])
         func.__doc__ = help
         return func
@@ -225,7 +225,7 @@ will be shown to select from the matching ones"""
             print "cd " + esc(repos[0].local_url)
         elif len(repos) > 1:
             for r in range(1, len(repos)+1):
-                sys.stderr.write("%d. %s\n" %(r,repos[r-1].local_url))
+                sys.stderr.write("{0:d}. {1!s}\n".format(r, repos[r-1].local_url))
 
 
             sys.stderr.write("\nSelect Repository: ")
@@ -270,7 +270,7 @@ RepoLister name (e.g. an SSHDir)"""
         else:
             remote_url = args[2]
 
-        print "Uploading '%s' to '%s' on %s" %(local_url, remote_url, lister.name)
+        print "Uploading '{0!s}' to '{1!s}' on {2!s}".format(local_url, remote_url, lister.name)
         sys.stdout.write("Proceed? (Y/n) ")
         a = raw_input()
         if a in ["", "y", "Y", "yes"]:
@@ -281,8 +281,7 @@ RepoLister name (e.g. an SSHDir)"""
 
         # Changing the origin remote
         if origin:
-            cmd = "cd %s; git remote rm origin; git remote add origin %s" \
-                  %(esc(repo.local_url), 
+            cmd = "cd {0!s}; git remote rm origin; git remote add origin {1!s}".format(esc(repo.local_url), 
                     esc(repo.clone_url))
             print cmd
             a = subprocess.Popen(cmd, shell = True)

--- a/gmp/policy.py
+++ b/gmp/policy.py
@@ -30,7 +30,7 @@ that it is only visible on your local machine."""
     def policy_serialize(self):
         ret = ""
         for (regexp, policy) in self.policies[1:]:
-            ret += ".add_policy(%s, %s)" %(repr(regexp),
+            ret += ".add_policy({0!s}, {1!s})".format(repr(regexp),
                                            repr(policy))
         return ret
         

--- a/gmp/repository.py
+++ b/gmp/repository.py
@@ -48,7 +48,7 @@ default_policy: defines if the repo can be cloned on all machines ("allow") or n
 
     def __str__(self):
         """A Repository can be serialized"""
-        ret = "%s(%s, %s, default_policy = %s, scm = %s)" %( 
+        ret = "{0!s}({1!s}, {2!s}, default_policy = {3!s}, scm = {4!s})".format( 
             self.__class__.__name__,
             repr(self.clone_url),
             repr(self.local_url),
@@ -68,7 +68,7 @@ default_policy: defines if the repo can be cloned on all machines ("allow") or n
         local = self.local_url
         if local.startswith(self.homedir):
             local = "~/" + local[len(self.homedir):]
-        return "%s (%s%s) %s --> %s" % (self.get_state(), 
+        return "{0!s} ({1!s}{2!s}) {3!s} --> {4!s}".format(self.get_state(), 
                                         self.scm.name, sets, 
                                         self.clone_url, local)
 

--- a/gmp/scm.py
+++ b/gmp/scm.py
@@ -94,7 +94,7 @@ class SCM:
 
         # Maybe we have to change the directory first
         if destdir:
-            command = "cd %s; %s" %(esc(destdir), command)
+            command = "cd {0!s}; {1!s}".format(esc(destdir), command)
 
         if parallel:
             command += " >/dev/null"
@@ -111,7 +111,7 @@ class SCM:
 
         for cmd in self.options.keys():
             for option in self.options[cmd]:
-                ret += ".add_option(%s, %s)" %(repr(cmd),
+                ret += ".add_option({0!s}, {1!s})".format(repr(cmd),
                                                repr(option))
         return ret
 
@@ -179,11 +179,10 @@ class GitSvn(Git):
         self.limit = limit
 
     def __str_keyword_arguments__(self):
-        return "(externals = %s, headonly = %s, limit = %s)" % \
-               (repr(self.externals), repr(self.headonly), repr(self.limit))
+        return "(externals = {0!s}, headonly = {1!s}, limit = {2!s})".format(repr(self.externals), repr(self.headonly), repr(self.limit))
 
     def __externals(self, destdir):
-        process = subprocess.Popen("cd %s; git svn propget svn:externals" % esc(destdir),
+        process = subprocess.Popen("cd {0!s}; git svn propget svn:externals".format(esc(destdir)),
                                    shell = True,
                                    stdout = subprocess.PIPE)
         process.wait()

--- a/gmp/tools.py
+++ b/gmp/tools.py
@@ -18,8 +18,7 @@ class ScreenExecutor:
 
     def push(cmd):
         i = ScreenExecutor.get()
-        i.screen_fd.write("""screen %d sh -c "echo; echo '%s' ; %s; echo Press ENTER;read a"\n""" 
-                          % (i.counter, cmd.replace("'", "\\\""), cmd))
+        i.screen_fd.write("""screen {0:d} sh -c "echo; echo '{1!s}' ; {2!s}; echo Press ENTER;read a"\n""".format(i.counter, cmd.replace("'", "\\\""), cmd))
         i.counter += 1
     push = staticmethod(push)
 
@@ -28,7 +27,7 @@ class ScreenExecutor:
             i = ScreenExecutor.get()
             i.screen_fd.write('caption always "%{wR}%c | %?%-Lw%?%{wB}%n*%f %t%?(%u)%?%{wR}%?%+Lw%?"\n')
             i.screen_fd.close()
-            a = subprocess.Popen("screen -c %s" % i.screen_path, shell=True)
+            a = subprocess.Popen("screen -c {0!s}".format(i.screen_path), shell=True)
             a.wait()
             
             os.unlink(i.screen_path)

--- a/manpage.py
+++ b/manpage.py
@@ -27,7 +27,7 @@ class ManPageFormatter(optparse.HelpFormatter):
         """
         if self.level == 0:
             return ''
-        return '.TP\n%s\n' % self._markup(heading.upper())
+        return '.TP\n{0!s}\n'.format(self._markup(heading.upper()))
  
     def format_option(self, option):
         """FORMAT A SINGLE OPTION.
@@ -35,9 +35,9 @@ class ManPageFormatter(optparse.HelpFormatter):
         """
         result = []
         opts = self.option_strings[option]
-        result.append('.TP\n.B\n%s\n' % self._markup(opts))
+        result.append('.TP\n.B\n{0!s}\n'.format(self._markup(opts)))
         if option.help:
-            help_text = '%s\n' % self._markup(self.expand_default(option))
+            help_text = '{0!s}\n'.format(self._markup(self.expand_default(option)))
             result.append(help_text)
         return ''.join(result)
 
@@ -61,11 +61,11 @@ class build_manpage(Command):
         appname = self.distribution.get_name()
         desc = self.distribution.get_description()
         m = self.parser.formatter._markup
-        stream.write(".TH %s 1 %s\n" %  (m(appname), datetime.datetime.today().strftime("%Y\\-%m\\-%d")))
-        stream.write(".SH NAME\n%s - %s\n" %(m(appname), m(desc)))
-        stream.write(".SH SYNPOSIS\n%s\n" % self.parser.get_usage())
-        stream.write(".SH DESCRIPTION\n%s\n" % m(self.distribution.get_long_description()))
-        stream.write(".SH OPTIONS\n%s\n" % self.parser.format_option_help())
+        stream.write(".TH {0!s} 1 {1!s}\n".format(m(appname), datetime.datetime.today().strftime("%Y\\-%m\\-%d")))
+        stream.write(".SH NAME\n{0!s} - {1!s}\n".format(m(appname), m(desc)))
+        stream.write(".SH SYNPOSIS\n{0!s}\n".format(self.parser.get_usage()))
+        stream.write(".SH DESCRIPTION\n{0!s}\n".format(m(self.distribution.get_long_description())))
+        stream.write(".SH OPTIONS\n{0!s}\n".format(self.parser.format_option_help()))
         stream.write(self.repo.generate_help(nroff=True) + "\n")
 
         stream.write(""".SH ENVIRON
@@ -74,10 +74,9 @@ class build_manpage(Command):
 METAGITRC
 use another config file instead of ~/.metagitrc
 """)
-        author = '%s <%s>' % (self.distribution.get_author(),
+        author = '{0!s} <{1!s}>'.format(self.distribution.get_author(),
                               self.distribution.get_author_email())
-        stream.write('.SH AUTHORS\n.B %s\nwas written by %s.\n'
-                    % (m(appname), m(author)))
+        stream.write('.SH AUTHORS\n.B {0!s}\nwas written by {1!s}.\n'.format(m(appname), m(author)))
         homepage = self.distribution.get_url()
         stream.write('.SH DISTRIBUTION\nThe latest version of %s may '
                     'be downloaded from\n'


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:metagit?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:metagit?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
